### PR TITLE
fix `f-string: unmatched '('`

### DIFF
--- a/core/bilibili.py
+++ b/core/bilibili.py
@@ -129,9 +129,9 @@ class Bilibili:
         if config.SILVER2COIN_OR_NOT and self.bilibili_http.inquire_live_info() > 700:
             silver_to_coin_res = self.bilibili_http.silver_to_coin()
             if silver_to_coin_res.get('status'):
-                self.log_and_push(f'转换成功～剩余瓜子{silver_to_coin_res.get('msg')}')
+                self.log_and_push(f"转换成功～剩余瓜子{silver_to_coin_res.get('msg')}")
             else:
-                self.log_and_push(f'转换失败-{silver_to_coin_res.get('msg')}')
+                self.log_and_push(f"转换失败-{silver_to_coin_res.get('msg')}")
         else:
             self.log_and_push('银瓜子转换币:跳过~')
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/ql/data/scripts/BilibiliDailyUp/main.py", line 7, in <module>
    from core.bilibili import Bilibili
  File "/ql/data/scripts/BilibiliDailyUp/core/bilibili.py", line 132
    self.log_and_push(f'转换成功～剩余瓜子{silver_to_coin_res.get('msg')}')